### PR TITLE
Update plugin priority to match aws-lambda plugin

### DIFF
--- a/kong/plugins/aws/handler.lua
+++ b/kong/plugins/aws/handler.lua
@@ -53,6 +53,6 @@ function plugin:access(plugin_conf)
   ngx.var.upstream_host = request.host
 end
 
-plugin.PRIORITY = 1000
+plugin.PRIORITY = 750
 
 return plugin


### PR DESCRIPTION
Changing to 750 to match the priority of the aws-lambda plugin, and so this plugin runs after the response-transformer plugin runs